### PR TITLE
[Reviewer: Andy] Don't make ping server the default

### DIFF
--- a/clearwater-nginx/etc/nginx/sites-available/ping
+++ b/clearwater-nginx/etc/nginx/sites-available/ping
@@ -1,6 +1,6 @@
 server {
-        listen      [::]:80 default_server ipv6only=off;
-        server_name localhost;
+        listen      [::]:80 ipv6only=off;
+        server_name ping;
 
         location /ping {
                  return 200;

--- a/clearwater-nginx/usr/share/clearwater-nginx/nginx.monit
+++ b/clearwater-nginx/usr/share/clearwater-nginx/nginx.monit
@@ -14,7 +14,7 @@ check process nginx pidfile /var/run/nginx.pid
          then exec "/usr/share/clearwater/bin/issue_alarm.py monit 5001.1"
 
   if failed host 127.0.0.1 port 80 protocol http
-     hostheader 'localhost'
+     hostheader 'ping'
      request "/ping"
      timeout 1 second
      for 3 cycles


### PR DESCRIPTION
Andy,

Please can you review this fix to make the ping server only respond if the host specified is "ping".  This is OK because we also control the monit configuration, so we can tell it to specify "ping".  I'll then specify ellis as the default server (see next pull request).

I prefer this approach over using a different port because there's a failure mode where one port binds OK and another does not - monit wouldn't detect that failure if ping was on a different port.

I've live-tested this, both in a normal deployment and in both flavors of AIO.  No doc updates are required.

Thanks,

Matt

(Fixes https://github.com/Metaswitch/ellis/issues/91)