### PR TITLE
[Reviewer: Andy] Let monit start clearwater-nginx

### DIFF
--- a/debian/clearwater-nginx.postinst
+++ b/debian/clearwater-nginx.postinst
@@ -62,7 +62,7 @@ case "$1" in
       # Remove the default config and enable the ping server.
       rm -f /etc/nginx/sites-enabled/default
       rm -f /etc/nginx/sites-available/default
-      nginx_ensite ping && service nginx reload
+      nginx_ensite ping
       mkdir -p /etc/nginx/ssl && cd /etc/nginx/ssl
       # Create a private key and a certificate signing request
       openssl req -nodes -sha256 -newkey rsa:2048 -keyout nginx.key -out nginx.csr -config nginx_openssl_config

--- a/debian/clearwater-nginx.postinst
+++ b/debian/clearwater-nginx.postinst
@@ -59,7 +59,6 @@ SRC_CONF_FILE=$SRC_CONF_DIR/nginx.monit
 case "$1" in
     configure)
       install $SRC_CONF_FILE $MONIT_CONF_FILE
-      sudo service nginx start
       # Remove the default config and enable the ping server.
       rm -f /etc/nginx/sites-enabled/default
       rm -f /etc/nginx/sites-available/default

--- a/debian/clearwater-nginx.postinst
+++ b/debian/clearwater-nginx.postinst
@@ -68,6 +68,7 @@ case "$1" in
       openssl req -nodes -sha256 -newkey rsa:2048 -keyout nginx.key -out nginx.csr -config nginx_openssl_config
       # Create a signed certificate using our own private key. Used for testing purposes.
       openssl x509 -sha256 -req -in nginx.csr -signkey nginx.key -out nginx.crt
+      service nginx stop || true
       reload clearwater-monit || true
     ;;
 


### PR DESCRIPTION
Andy,

Please can you review this fix to #17?  Since monit now manages nginx, there's no need to start it ourselves (and indeed this fails if it's already running).  I've tested live.

Thanks,

Matt