### PR TITLE
[Reviewer: None] Use updated check-uptime script.

### DIFF
--- a/clearwater-nginx/usr/share/clearwater-nginx/nginx.monit
+++ b/clearwater-nginx/usr/share/clearwater-nginx/nginx.monit
@@ -56,8 +56,8 @@ check process nginx_process pidfile /var/run/nginx.pid
      then restart
 
 # Clear any alarms if the process has been running long enough.
-check program nginx_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/nginx.pid"
+check program nginx_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/nginx.pid monit 5001.1"
   group nginx
   depends on nginx_process
   every 3 cycles
-  if status = 0 then exec "/usr/share/clearwater/bin/issue_alarm.py monit 5001.1"
+  if status != 0 then alert


### PR DESCRIPTION
Use check-uptime to clear alarms and avoid suprious monit failures.