### PR TITLE
[Reviewer: Rob] Increase server hash size to 64

### DIFF
--- a/debian/clearwater-nginx.transform
+++ b/debian/clearwater-nginx.transform
@@ -1,0 +1,1 @@
+/etc/nginx/nginx.conf.clearwater sed -e 's/# server_names_hash_bucket_size .*$/server_names_hash_bucket_size 64;/g'

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 # clearwater-infrastructure explicitly checks for packages of this name when
 # updating
 Maintainer: Project Clearwater Maintainers <maintainers@projectclearwater.org>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), config-package-dev
 Standards-Version: 3.9.2
 Homepage: http://projectclearwater.org/
 
@@ -13,4 +13,6 @@ Package: clearwater-nginx
 Architecture: all
 Depends: nginx (>= 1.1.19), openssl, clearwater-infrastructure
 Suggests: clearwater-snmp-handler-alarm
+Provides: ${diverted-files}
+Conflicts: ${diverted-files}
 Description: Nginx configured for Clearwater

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@
 export DH_OPTIONS
 
 %:
-	dh $@
+	dh $@ --with=config-package
 
 # Don't clean, build, test or install
 override_dh_auto_clean:


### PR DESCRIPTION
Rob,

Please can you review this fix to increase the server hash size for nginx?  We've seen issues around this a number of times with long domain names, and I've also seen problems on AArch64 (where I guess that the different architecture means that domain names take more space in some way).

Tested live.

Matt