### PR TITLE
[Reviewer: AJH] Make ping listen on localhost only

### DIFF
--- a/clearwater-nginx/etc/nginx/sites-available/ping
+++ b/clearwater-nginx/etc/nginx/sites-available/ping
@@ -1,5 +1,5 @@
 server {
-        listen      [::]:80 ipv6only=off;
+        listen      [::1]:80 ipv6only=off;
         server_name ping;
 
         location /ping {


### PR DESCRIPTION
We shouldn't be listening for external requests on port 80. This modifies 'ping' so that we're listening on localhost only. This also circumvents the issue of the apachekiller vulnerability; it would be easy to add that config in here to 'close' it, but that doesn't seem necessary to me if we're not listening to external traffic. (Shout if you disagree with that assessment.)

Tested on a live system, we're not listening for external requests on port 80 anymore (and there are no complaints from nmap) but we still respond to pings from localhost.