### PR TITLE
Revert "[Reviewer: AJH] Make ping listen on localhost only"

### DIFF
--- a/clearwater-nginx/etc/nginx/sites-available/ping
+++ b/clearwater-nginx/etc/nginx/sites-available/ping
@@ -1,5 +1,5 @@
 server {
-        listen      [::1]:80 ipv6only=off;
+        listen      [::]:80 ipv6only=off;
         server_name ping;
 
         location /ping {


### PR DESCRIPTION
Reverts Metaswitch/clearwater-nginx#44

This change broke Ellis, which binds to `[::]:80` - we can't bind sites to different addresses on the same port. Further discussion is required on what to do about this, so I'm backing this out for now.