### PR TITLE
[Reviewer: RJW2] Move ping to localhost port 8000

### DIFF
--- a/clearwater-nginx/etc/nginx/sites-available/ping
+++ b/clearwater-nginx/etc/nginx/sites-available/ping
@@ -1,5 +1,6 @@
 server {
-        listen      [::1]:8000 ipv6only=off;
+        listen      [::1]:8000;
+        listen      127.0.0.1:8000;
         server_name ping;
 
         location /ping {

--- a/clearwater-nginx/etc/nginx/sites-available/ping
+++ b/clearwater-nginx/etc/nginx/sites-available/ping
@@ -1,5 +1,5 @@
 server {
-        listen      [::]:80 ipv6only=off;
+        listen      [::1]:8000 ipv6only=off;
         server_name ping;
 
         location /ping {

--- a/clearwater-nginx/usr/share/clearwater-nginx/nginx_ping
+++ b/clearwater-nginx/usr/share/clearwater-nginx/nginx_ping
@@ -9,5 +9,5 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-/usr/share/clearwater-nginx/run-in-nginx-namespace curl 127.0.0.1:80/ping
+/usr/share/clearwater-nginx/run-in-nginx-namespace curl 127.0.0.1:8000/ping
 exit $?


### PR DESCRIPTION
As discussed, this change:

* Limits ping to listen on localhost only;
* Moves it to port 8000;
* Corrects the `nginx_ping` script to poll on port 8000.

After this change, Ellis will require an accompanying change or it will be broken (again) - I'll be creating that PR shortly and referencing this.

I have tested this change on both a CWC deployment, and an AWS PC deployment (with the above-mentioned ellis fix in place), applied to all Clearwater nodes that run nginx, and tested using the live test suite. The tests pass, and all nodes report healthy across the board, so I don't think I've missed anything.