### PR TITLE
[Reviewer: MGM] Remove ping binding to IPv6 localhost

### DIFF
--- a/clearwater-nginx/etc/nginx/sites-available/ping
+++ b/clearwater-nginx/etc/nginx/sites-available/ping
@@ -1,5 +1,4 @@
 server {
-        listen      [::1]:8000;
         listen      127.0.0.1:8000;
         server_name ping;
 


### PR DESCRIPTION
As discussed in emails: this breaks clearwater-docker, and we don't have anything that pings this 'site' on IPv6, so let's just remove it.

You mentioned that this ended up making it into the PC release - should this also go into the `stable` branch?